### PR TITLE
fix: replace operator""_format by fmt::format

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -44,7 +44,7 @@ void BasicApp::pre()
 void BasicApp::post()
 {
     osmium::MemoryUsage mem;
-    vout() << "Overall memory usage: {} MByte current, {} MBytes peak\n"_format(
+    vout() << fmt::format( "Overall memory usage: {} MByte current, {} MBytes peak\n",
         mem.current(), mem.peak());
 
     vout() << "Done.\n";

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -55,7 +55,7 @@ int run_app(int argc, char *argv[]) noexcept
         } catch (CLI::ParseError const &e) {
             return app.exit(e) > 0 ? 2 : 0;
         } catch (std::exception const &e) {
-            fmt::print(stderr, "Error: {}\n"_format(e.what()));
+            fmt::print(stderr, "Error: {}\n", e.what());
             return 1;
         }
     } catch (...) {

--- a/src/osp-analyze-relation-types.cpp
+++ b/src/osp-analyze-relation-types.cpp
@@ -237,21 +237,21 @@ public:
         TypeMap types;
         vout() << "Reading relations...\n";
         auto ids = read_relations(input_file, &types);
-        vout() << "Found {} different type tags.\n"_format(types.size());
+        vout() << fmt::format( "Found {:z} different type tags.\n", types.size());
         types.insert_into_db(&db);
 
         vout() << "Reading ways...\n";
         read_ways(input_file, &ids);
         sort_unique(&ids.nodes());
 
-        vout() << "Data to copy: {} nodes, {} ways, {} relations.\n"_format(
+        vout() << fmt::format( "Data to copy: {} nodes, {} ways, {} relations.\n",
             ids.nodes().size(), ids.ways().size(), ids.relations().size());
 
         std::vector<std::unique_ptr<osmium::io::Writer>> writers;
         writers.reserve(types.size());
         for (auto const &type : types) {
             writers.emplace_back(std::make_unique<osmium::io::Writer>(
-                "{}/{}.osm.pbf"_format(output(),
+                fmt::format("{}/{}.osm.pbf",output(),
                                        TypeMap::generate_filename(type.first)),
                 osmium::io::overwrite::allow));
         }

--- a/src/osp-filter-relations-and-members.cpp
+++ b/src/osp-filter-relations-and-members.cpp
@@ -108,22 +108,22 @@ public:
         vout() << "Done processing.\n";
 
         for (auto t : nwr) {
-            vout() << "Copied {}/{} ({}%) {}s.\n"_format(
+            vout() << fmt::format("Copied {}/{} ({}%) {}s.\n",
                 counts_out(t), counts_in(t),
                 percent(counts_out(t), counts_in(t)),
                 osmium::item_type_to_name(t));
         }
         for (auto t : nwr) {
             if (ids(t).empty()) {
-                vout() << "All {}s found.\n"_format(
+                vout() << fmt::format( "All {}s found.\n",
                     osmium::item_type_to_name(t));
             } else {
-                vout() << "Missing {} {}s.\n"_format(
+                vout() << fmt::format( "Missing {} {}s.\n",
                     ids(t).size(), osmium::item_type_to_name(t));
             }
         }
         for (auto t : nwr) {
-            vout() << "Memory used for {} id indexes: {} MBytes.\n"_format(
+            vout() << fmt::format("Memory used for {} id indexes: {} MBytes.\n",
                 osmium::item_type_to_name(t), mbytes(ids(t).used_memory()));
         }
     }

--- a/src/osp-history-stats-basic.cpp
+++ b/src/osp-history-stats-basic.cpp
@@ -190,7 +190,7 @@ public:
 
         std::array<int64_t, num_variables> counters{0};
         for (auto time = m_stats.size() - 1; time > 0; --time) {
-            std::string const dm = "-{} days"_format(time);
+            std::string const dm = fmt::format("-{} days", time);
 
             calculate_derived_stats(time);
 

--- a/src/osp-stats-way-node-refs-delta.cpp
+++ b/src/osp-stats-way-node-refs-delta.cpp
@@ -65,7 +65,7 @@ public:
         auto const basis =
             static_cast<double>(m_way_nodes_count - m_way_count) / 100.0;
 
-        std::cout << ": {:10d} (~ {:5.2f}%)\n"_format(m_distance[i],
+        fmt::print( ": {:10d} (~ {:5.2f}%)\n", m_distance[i],
                                                       m_distance[i] / basis);
     }
 


### PR DESCRIPTION
   because {fmt} library 9.x does not support it any more.
   
   Homebrew (MacOS) uses fmt version 9.0.0.
   If compiling [osmium-surplus](https://github.com/osmcode/osmium-surplus) without this patch, one gets errors like these:
   ```
..../osmium-surplus/src/app.hpp:58:32: error: unable to find string literal operator 'operator""_format' with 'const char [11]', 'long unsigned int' arguments
   58 |             fmt::print(stderr, "Error: {}\n"_format(e.what()));
      |                                ^~~~~~~~~~~~~~~~~~~~
```

I am aware that we might lose compile time format diagnostics with the patch.

I double checked that current debian and MacOS: Now both do compile with this patch.